### PR TITLE
Correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 38 Arduino libraries for Click boards™ provided by Lextronic
+# 38 Arduino sketches for Click boards™ provided by Lextronic
 
 documentation is here in french:  
 https://docs.google.com/viewer?url=https://github.com/BlackBrix/Arduino-libraries-for-Click-boards/raw/master/docs/Click_App_TOME1.pdf  


### PR DESCRIPTION
README.md claimed "38 Arduino libraries for Click boards™ provided by Lextronic" but in fact this repository doesn't contain any libraries. It contains Arduino sketches.

You should also correct the repository description. That can not be done via a pull request but it's easily done by clicking the **Edit** button to the right of the description text shown at the top of the repository's home page:
https://github.com/BlackBrix/Arduino-libraries-for-Click-boards

I also recommend renaming the repository, which you can do from the settings page:
https://github.com/BlackBrix/Arduino-libraries-for-Click-boards/settings